### PR TITLE
Fix zsh detection of curl/shells/shebangs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -140,18 +140,18 @@ programs_required_one() {
 # Find proper shebang for the launcher script
 find_shebang() {
 	# Detect where is the 'env' found in order to set properly the shebang
-	local shebang_dependencies="/usr/bin/env /bin/env"
-	local shebang_program=$(programs_required_one ${shebang_dependencies})
+	local shebang_dependencies=("/usr/bin/env" "/bin/env")
+	local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
 
 	if [ -z "${shebang_program}" ]; then
-		warning "None of the following programs are installed: ${shebang_dependencies}. Trying to detect common shells..."
+		warning "None of the following programs are installed: ${shebang_dependencies[@]}. Trying to detect common shells..."
 
 		# Check common shells
-		local shebang_dependencies="/bin/sh /bin/bash /bin/dash"
-		local shebang_program=$(programs_required_one ${shebang_dependencies})
+		local shebang_dependencies=("/bin/sh" "/bin/bash" "/bin/dash")
+		local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
 
 		if [ -z "${shebang_program}" ]; then
-			err "None of the following programs are installed: ${shebang_dependencies}. One of them is required at least to find the shell. Aborting installation."
+			err "None of the following programs are installed: ${shebang_dependencies[@]}. One of them is required at least to find the shell. Aborting installation."
 			exit 1
 		else
 			# Set up shebang command
@@ -180,11 +180,11 @@ dependencies() {
 
 	# Check if download programs are installed
 	if [ $OPT_FROM_PATH -eq 0 ]; then
-		local download_dependencies="curl wget"
-		local download_program=$(programs_required_one ${download_dependencies})
+		local download_dependencies=("curl" "wget")
+		local download_program=$(programs_required_one ${download_dependencies[@]})
 
 		if [ -z "${download_program}" ]; then
-			err "None of the following programs are installed: ${download_dependencies}. One of them is required at least to download the tarball. Aborting installation."
+			err "None of the following programs are installed: ${download_dependencies[@]}. One of them is required at least to download the tarball. Aborting installation."
 			exit 1
 		fi
 
@@ -210,10 +210,10 @@ operative_system() {
 
 	# TODO: Implement other operative systems in metacall/distributable-linux
 	case ${os} in
-		# Darwin)
-		# 	echo "osx"
-		# 	return
-		# 	;;
+		Darwin)
+			echo "osx"
+			return
+			;;
 		# FreeBSD)
 		# 	echo "freebsd"
 		# 	return


### PR DESCRIPTION
* Replaced some strings for zsh by bash arrays in order to fix this issue 
```zsh
➜  install git:(master) ✗ zsh -x install.sh
+install.sh:21> OPT_DOCKER_INSTALL=0 
+install.sh:22> OPT_NO_CHECK_CERTIFICATE=0 
+install.sh:23> OPT_NO_DOCKER_FALLBACK=0 
+install.sh:24> OPT_UPDATE=0 
+install.sh:25> OPT_UNINSTALL=0 
+install.sh:26> OPT_FROM_PATH=0 
+install.sh:27> OPT_FROM_PATH_TARGET='' 
+install.sh:30> CMD_DOWNLOAD='' 
+install.sh:31> CMD_SHEBANG='' 
+install.sh:34> [ 0 -ne 0 ']'
+install.sh:66> program tput
+program:1> command -v tput
+install.sh:67> ncolors=+install.sh:67> tput colors
+install.sh:67> ncolors=256 
+install.sh:68> [ -n 256 ']'
+install.sh:68> [ 256 -ge 8 ']'
+install.sh:69> bold=+install.sh:69> tput bold
+install.sh:69> bold=$'\C-[[1m' 
+install.sh:70> normal=+install.sh:70> tput sgr0
+install.sh:70> normal=$'\C-[(B\C-[[m' 
+install.sh:71> black=+install.sh:71> tput setaf 0
+install.sh:71> black=$'\C-[[30m' 
+install.sh:72> red=+install.sh:72> tput setaf 1
+install.sh:72> red=$'\C-[[31m' 
+install.sh:73> green=+install.sh:73> tput setaf 2
+install.sh:73> green=$'\C-[[32m' 
+install.sh:74> yellow=+install.sh:74> tput setaf 3
+install.sh:74> yellow=$'\C-[[33m' 
+install.sh:75> blue=+install.sh:75> tput setaf 4
+install.sh:75> blue=$'\C-[[34m' 
+install.sh:76> magenta=+install.sh:76> tput setaf 5
+install.sh:76> magenta=$'\C-[[35m' 
+install.sh:77> cyan=+install.sh:77> tput setaf 6
+install.sh:77> cyan=$'\C-[[36m' 
+install.sh:78> white=+install.sh:78> tput setaf 7
+install.sh:78> white=$'\C-[[37m' 
+install.sh:665> main
+main:2> [ 0 -eq 1 ']'
+main:9> program metacall
+program:1> command -v metacall
+main:19> [ 0 -eq 1 ']'
+main:25> programs_required wait
+programs_required:1> prog=wait
+programs_required:2> program wait
+program:1> command -v wait
+main:27> [ 0 -eq 1 ']'
+main:39> binary_install
+binary_install:2> title 'MetaCall Self-Contained Binary Installer'
+main:40> proc=1665 
+title:1> printf '%b\n\n' $'\C-[(B\C-[[m\C-[[1mMetaCall Self-Contained Binary Installer\C-[(B\C-[[m'
MetaCall Self-Contained Binary Installer

+binary_install:5> dependencies
+main:41> wait 1665
+dependencies:1> print 'Checking system dependencies.'
+print:1> printf '%b\n' $'\C-[(B\C-[[m\M-^V Checking system dependencies.'
▷ Checking system dependencies.
+dependencies:4> [ 0 -eq 0 ']'
+dependencies:5> programs_required tar grep tail awk rev cut uname echo printf rm id head chmod chown ln
+programs_required:1> prog=tar
+programs_required:2> program tar
+program:1> command -v tar
+programs_required:1> prog=grep
+programs_required:2> program grep
+program:1> command -v grep
+programs_required:1> prog=tail
+programs_required:2> program tail
+program:1> command -v tail
+programs_required:1> prog=awk
+programs_required:2> program awk
+program:1> command -v awk
+programs_required:1> prog=rev
+programs_required:2> program rev
+program:1> command -v rev
+programs_required:1> prog=cut
+programs_required:2> program cut
+program:1> command -v cut
+programs_required:1> prog=uname
+programs_required:2> program uname
+program:1> command -v uname
+programs_required:1> prog=echo
+programs_required:2> program echo
+program:1> command -v echo
+programs_required:1> prog=printf
+programs_required:2> program printf
+program:1> command -v printf
+programs_required:1> prog=rm
+programs_required:2> program rm
+program:1> command -v rm
+programs_required:1> prog=id
+programs_required:2> program id
+program:1> command -v id
+programs_required:1> prog=head
+programs_required:2> program head
+program:1> command -v head
+programs_required:1> prog=chmod
+programs_required:2> program chmod
+program:1> command -v chmod
+programs_required:1> prog=chown
+programs_required:2> program chown
+program:1> command -v chown
+programs_required:1> prog=ln
+programs_required:2> program ln
+program:1> command -v ln
+dependencies:10> id -u
+dependencies:10> [ 501 -ne 0 ']'
+dependencies:11> programs_required tee
+programs_required:1> prog=tee
+programs_required:2> program tee
+program:1> command -v tee
+dependencies:15> [ 0 -eq 0 ']'
+dependencies:16> local download_dependencies=( curl wget )
+dependencies:17> programs_required_one curl wget
+programs_required_one:1> prog=curl
+programs_required_one:2> program curl
+program:1> command -v curl
+programs_required_one:3> echo curl
+programs_required_one:4> return
+dependencies:17> local download_program=curl
+dependencies:19> [ -z curl ']'
+dependencies:25> CMD_DOWNLOAD=curl 
+dependencies:29> find_shebang
+find_shebang:2> local shebang_dependencies=( '/usr/bin/env /bin/env' )
+find_shebang:3> programs_required_one '/usr/bin/env /bin/env'
+programs_required_one:1> prog=/usr/bin/env /bin/env
+programs_required_one:2> program '/usr/bin/env /bin/env'
+program:1> command -v '/usr/bin/env /bin/env'
+find_shebang:3> local shebang_program=''
+find_shebang:5> [ -z '' ']'
+find_shebang:6> warning 'None of the following programs are installed: /usr/bin/env /bin/env. Trying to detect common shells...'
+warning:1> printf '%b\n' $'\C-[[33m\M-^@\C-[(B\C-[[m None of the following programs are installed: /usr/bin/env /bin/env. Trying to detect common shells...'
‼ None of the following programs are installed: /usr/bin/env /bin/env. Trying to detect common shells...
+find_shebang:9> local shebang_dependencies=( '/bin/sh /bin/bash /bin/dash' )
+find_shebang:10> programs_required_one '/bin/sh /bin/bash /bin/dash'
+programs_required_one:1> prog=/bin/sh /bin/bash /bin/dash
+programs_required_one:2> program '/bin/sh /bin/bash /bin/dash'
+program:1> command -v '/bin/sh /bin/bash /bin/dash'
+find_shebang:10> local shebang_program=''
+find_shebang:12> [ -z '' ']'
+find_shebang:13> err 'None of the following programs are installed: /bin/sh /bin/bash /bin/dash. One of them is required at least to find the shell. Aborting installation.'
+err:1> printf '%b\n' $'\C-[[31m\M-^\\M-^X\C-[(B\C-[[m None of the following programs are installed: /bin/sh /bin/bash /bin/dash. One of them is required at least to find the shell. Aborting installation.'
✘ None of the following programs are installed: /bin/sh /bin/bash /bin/dash. One of them is required at least to find the shell. Aborting installation.
+find_shebang:14> exit 1
+main:42> result=1 
+main:44> [ 1 -ne 0 ']'
+main:46> [ 0 -eq 1 ']'
+main:51> programs_required read
+programs_required:1> prog=read
+programs_required:2> program read
+program:1> command -v read
+main:54> case 569Xx (*i*)
+main:54> case 569Xx (*)
+main:56> local interactive=0
+main:59> [ 0 -ne 0 ']'
+main:64> warning 'Binary installation has failed, fallback to Docker installation.'
+warning:1> printf '%b\n' $'\C-[[33m\M-^@\C-[(B\C-[[m Binary installation has failed, fallback to Docker installation.'
‼ Binary installation has failed, fallback to Docker installation.
+main:69> proc=1670 
+main:70> wait 1670
+main:68> docker_install
+docker_install:2> title 'MetaCall Docker Installer'
+title:1> printf '%b\n\n' $'\C-[(B\C-[[m\C-[[1mMetaCall Docker Installer\C-[(B\C-[[m'
MetaCall Docker Installer

+docker_install:5> print 'Checking Docker Dependency.'
+print:1> printf '%b\n' $'\C-[(B\C-[[m\M-^V Checking Docker Dependency.'
▷ Checking Docker Dependency.
+docker_install:7> programs_required docker echo chmod
+programs_required:1> prog=docker
+programs_required:2> program docker
+program:1> command -v docker
+programs_required:3> err 'The program '\''docker'\'' is not found, it is required to run the installer. Aborting installation.'
+err:1> printf '%b\n' $'\C-[[31m\M-^\\M-^X\C-[(B\C-[[m The program \'docker\' is not found, it is required to run the installer. Aborting installation.'
✘ The program 'docker' is not found, it is required to run the installer. Aborting installation.
+programs_required:4> exit 1
+main:71> result=1 
+main:73> [ 1 -ne 0 ']'
+main:74> exit 1
```