### PR TITLE
[FIX] Fixed difference in array implementation in POSIX sh and bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -140,18 +140,27 @@ programs_required_one() {
 # Find proper shebang for the launcher script
 find_shebang() {
 	# Detect where is the 'env' found in order to set properly the shebang
-	local shebang_dependencies=("/usr/bin/env" "/bin/env")
-	local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
+	# The below two lines work fine when running `bash install.sh` but throw an error when running `sh install.sh`
+	#local shebang_dependencies=("/usr/bin/env" "/bin/env")
+	#local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
+	
+	shebang_dependencies="/usr/bin/env /bin/env"
+	set -- $shebang_dependencies
+	local shebang_program=$(programs_required_one $@)
 
 	if [ -z "${shebang_program}" ]; then
-		warning "None of the following programs are installed: ${shebang_dependencies[@]}. Trying to detect common shells..."
+		warning "None of the following programs are installed: $@}. Trying to detect common shells..."
 
 		# Check common shells
-		local shebang_dependencies=("/bin/sh" "/bin/bash" "/bin/dash")
-		local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
-
+		# The below two lines work fine when running `bash install.sh` but throw an error when running `sh install.sh`
+		#local shebang_dependencies=("/bin/sh" "/bin/bash" "/bin/dash")
+		#local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
+		shebang_dependencies="/bin/sh /bin/bash /bin/dash"
+		set -- $shebang_dependencies
+		local shebang_program=$(programs_required_one $@)
+		
 		if [ -z "${shebang_program}" ]; then
-			err "None of the following programs are installed: ${shebang_dependencies[@]}. One of them is required at least to find the shell. Aborting installation."
+			err "None of the following programs are installed: $@. One of them is required at least to find the shell. Aborting installation."
 			exit 1
 		else
 			# Set up shebang command
@@ -180,8 +189,12 @@ dependencies() {
 
 	# Check if download programs are installed
 	if [ $OPT_FROM_PATH -eq 0 ]; then
-		local download_dependencies=("curl" "wget")
-		local download_program=$(programs_required_one ${download_dependencies[@]})
+		# The below two lines work fine when running `bash install.sh` but throw an error when running `sh install.sh`
+		#local download_dependencies=("curl" "wget")
+		#local download_program=$(programs_required_one ${download_dependencies[@]})
+		download_dependencies="curl wget"
+		set -- $download_dependencies
+		local download_program=$(programs_required_one $@)
 
 		if [ -z "${download_program}" ]; then
 			err "None of the following programs are installed: ${download_dependencies[@]}. One of them is required at least to download the tarball. Aborting installation."

--- a/install.sh
+++ b/install.sh
@@ -143,13 +143,13 @@ find_shebang() {
 	local shebang_program=$(programs_required_one /usr/bin/env /bin/env)
 
 	if [ -z "${shebang_program}" ]; then
-		warning "None of the following programs are installed: $@}. Trying to detect common shells..."
+		warning "None of the following programs are installed: /usr/bin/env /bin/env. Trying to detect common shells..."
 
 		# Check common shells
 		local shebang_program=$(programs_required_one /bin/sh /bin/bash /bin/dash)
 		
 		if [ -z "${shebang_program}" ]; then
-			err "None of the following programs are installed: $@. One of them is required at least to find the shell. Aborting installation."
+			err "None of the following programs are installed: /bin/sh /bin/bash /bin/dash. One of them is required at least to find the shell. Aborting installation."
 			exit 1
 		else
 			# Set up shebang command
@@ -181,7 +181,7 @@ dependencies() {
 		local download_program=$(programs_required_one curl wget)
 
 		if [ -z "${download_program}" ]; then
-			err "None of the following programs are installed: ${download_dependencies[@]}. One of them is required at least to download the tarball. Aborting installation."
+			err "None of the following programs are installed: curl wget. One of them is required at least to download the tarball. Aborting installation."
 			exit 1
 		fi
 

--- a/install.sh
+++ b/install.sh
@@ -140,24 +140,13 @@ programs_required_one() {
 # Find proper shebang for the launcher script
 find_shebang() {
 	# Detect where is the 'env' found in order to set properly the shebang
-	# The below two lines work fine when running `bash install.sh` but throw an error when running `sh install.sh`
-	#local shebang_dependencies=("/usr/bin/env" "/bin/env")
-	#local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
-	
-	shebang_dependencies="/usr/bin/env /bin/env"
-	set -- $shebang_dependencies
-	local shebang_program=$(programs_required_one $@)
+	local shebang_program=$(programs_required_one /usr/bin/env /bin/env)
 
 	if [ -z "${shebang_program}" ]; then
 		warning "None of the following programs are installed: $@}. Trying to detect common shells..."
 
 		# Check common shells
-		# The below two lines work fine when running `bash install.sh` but throw an error when running `sh install.sh`
-		#local shebang_dependencies=("/bin/sh" "/bin/bash" "/bin/dash")
-		#local shebang_program=$(programs_required_one ${shebang_dependencies[@]})
-		shebang_dependencies="/bin/sh /bin/bash /bin/dash"
-		set -- $shebang_dependencies
-		local shebang_program=$(programs_required_one $@)
+		local shebang_program=$(programs_required_one /bin/sh /bin/bash /bin/dash)
 		
 		if [ -z "${shebang_program}" ]; then
 			err "None of the following programs are installed: $@. One of them is required at least to find the shell. Aborting installation."
@@ -189,12 +178,7 @@ dependencies() {
 
 	# Check if download programs are installed
 	if [ $OPT_FROM_PATH -eq 0 ]; then
-		# The below two lines work fine when running `bash install.sh` but throw an error when running `sh install.sh`
-		#local download_dependencies=("curl" "wget")
-		#local download_program=$(programs_required_one ${download_dependencies[@]})
-		download_dependencies="curl wget"
-		set -- $download_dependencies
-		local download_program=$(programs_required_one $@)
+		local download_program=$(programs_required_one curl wget)
 
 		if [ -z "${download_program}" ]; then
 			err "None of the following programs are installed: ${download_dependencies[@]}. One of them is required at least to download the tarball. Aborting installation."


### PR DESCRIPTION
# Description
While running the install script via the POSIX sh shell, a error is thrown as POSIX sh doesn't support arrays
Fixed the error by just hardcoding the array values in the required places as it was not called more than once


The change works with both bash and sh

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

