### PR TITLE
install.sh: Fix path for python libs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -359,7 +359,7 @@ uncompress() {
 # Install the CLI
 cli() {
 	local cli="/gnu/store/`ls /gnu/store/ | grep metacall | head -n 1`"
-	local pythonpath_base="/gnu/store/`ls /gnu/store/ | grep python-next-3 | head -n 1`/lib"
+	local pythonpath_base="/gnu/store/`ls /gnu/store/ | grep python-3 | head -n 1`/lib"
 	local pythonpath_dynlink="`ls -d ${pythonpath_base}/*/ | grep 'python3\.[0-9]*\/$'`lib-dynload"
 
 	print "Installing the Command Line Interface shortcut (needs sudo or root permissions)."


### PR DESCRIPTION
Doing this will fix  `ls: cannot access '/gnu/store//lib/*/': No such file or directory` during installation which is raised by invalid path name on the script