### PR TITLE
To facilitate workflow triggers from the distributables

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,6 +1,6 @@
 name: Install Metacall on Linux Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   install-default:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,6 @@
 name: Install Metacall on Windows Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   install-default:


### PR DESCRIPTION
Workflow dispatch is needed for the workflows to get triggered from their respective distributables i.e test-linux from distributable linux and test-windows from distributable windows

Related to [#22](https://github.com/metacall/distributable-windows/pull/22) and [#12](https://github.com/metacall/distributable-linux/pull/12)