### PR TITLE
Fix: Added Warning Note for raw.githubusercontent.com blocked by ISP

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ The following scripts are provided in order to install MetaCall:
 - [install.ps1](https://raw.githubusercontent.com/metacall/install/master/install.ps1) `PowerShell | Windows`
 
 In order to install MetaCall in one line, curl or wget or powershell can be used:
-
-- `curl`
+- `curl`:
   ```sh
   curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
   ```
-- `wget`
+- `wget`:
   ```sh
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
   ```

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Cross-platform set of scripts to install MetaCall Core infrastructure. For advan
 # Install
 
 The following scripts are provided in order to install MetaCall:
+
 - [install.sh](https://raw.githubusercontent.com/metacall/install/master/install.sh) `bash or zsh | Linux or MacOS`
 
 - [install.ps1](https://raw.githubusercontent.com/metacall/install/master/install.ps1) `PowerShell | Windows`
 
 In order to install MetaCall in one line, curl or wget or powershell can be used:
+
 - `curl`:
   ```sh
   curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
@@ -24,9 +26,12 @@ In order to install MetaCall in one line, curl or wget or powershell can be used
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
   ```
 - `powershell`:
+
   ```powershell
   powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
   ```
+
+- Note - Sometimes, the domain _raw.githubusercontent.com_ maybe blocked by your ISP. Due to this, you may not be able to install metacall directly from above commands. In that case, you may clone this repo and directly run [install.sh](https://github.com/metacall/install/blob/master/install.sh) for Linux and run [install.ps1](https://github.com/metacall/install/blob/master/install.ps1) for Windows.
 
 ## Install Linux or MacOS
 
@@ -42,16 +47,19 @@ Additional parameters for the install script:
 Example usage:
 
 - Install with `curl` without checking certificates and without docker fallback:
+
   ```sh
   curl --insecure -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --no-check-certificate --no-docker-fallback
   ```
 
 - Install with `wget` using Docker installer:
+
   ```sh
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --docker-install
   ```
 
 - Install with `wget` from a existing tarball located at `/root/downloads/metacall-tarball-linux-amd64.tar.gz`:
+
   ```sh
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --from-path /root/downloads/metacall-tarball-linux-amd64.tar.gz
   ```

--- a/README.md
+++ b/README.md
@@ -17,21 +17,19 @@ The following scripts are provided in order to install MetaCall:
 
 In order to install MetaCall in one line, curl or wget or powershell can be used:
 
-- `curl`:
+- `curl`
   ```sh
   curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
   ```
-- `wget`:
+- `wget`
   ```sh
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
   ```
-- `powershell`:
+- `powershell`
 
   ```powershell
   powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
   ```
-
-- Note - Sometimes, the domain _raw.githubusercontent.com_ maybe blocked by your ISP. Due to this, you may not be able to install metacall directly from above commands. In that case, you may clone this repo and directly run [install.sh](https://github.com/metacall/install/blob/master/install.sh) for Linux and run [install.ps1](https://github.com/metacall/install/blob/master/install.ps1) for Windows.
 
 ## Install Linux or MacOS
 
@@ -89,3 +87,6 @@ Example usage:
 ```sh
 ./test.sh
 ```
+
+# Troubleshooting
+Sometimes the domain _raw.githubusercontent.com_ maybe blocked by your ISP. Due to this, you may not be able to install metacall directly from previous commands. In that case, you may clone this repo and directly run [install.sh](https://github.com/metacall/install/blob/master/install.sh) for Linux and run [install.ps1](https://github.com/metacall/install/blob/master/install.ps1) for Windows.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In order to install MetaCall in one line, curl or wget or powershell can be used
   ```sh
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
   ```
-- `powershell`
+- `powershell`:
 
   ```powershell
   powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Cross-platform set of scripts to install MetaCall Core infrastructure. For advan
 # Install
 
 The following scripts are provided in order to install MetaCall:
-
 - [install.sh](https://raw.githubusercontent.com/metacall/install/master/install.sh) `bash or zsh | Linux or MacOS`
 
 - [install.ps1](https://raw.githubusercontent.com/metacall/install/master/install.ps1) `PowerShell | Windows`
@@ -25,7 +24,6 @@ In order to install MetaCall in one line, curl or wget or powershell can be used
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
   ```
 - `powershell`:
-
   ```powershell
   powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/metacall/install/master/install.ps1')))"
   ```
@@ -44,19 +42,16 @@ Additional parameters for the install script:
 Example usage:
 
 - Install with `curl` without checking certificates and without docker fallback:
-
   ```sh
   curl --insecure -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --no-check-certificate --no-docker-fallback
   ```
 
 - Install with `wget` using Docker installer:
-
   ```sh
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --docker-install
   ```
 
 - Install with `wget` from a existing tarball located at `/root/downloads/metacall-tarball-linux-amd64.tar.gz`:
-
   ```sh
   wget -O - https://raw.githubusercontent.com/metacall/install/master/install.sh | sh -s -- --from-path /root/downloads/metacall-tarball-linux-amd64.tar.gz
   ```


### PR DESCRIPTION
While installing metacall by the already steps mentioned in readme, I wasn't able to install it. The problem was that the domain raw.githubusercontent.com was blocked by my ISP. Also, I found that it was happening with many people on a Github discussion (https://github.com/orgs/community/discussions/42655).

It would be good if we mention this beforehand as it would help the new contributors on this repo.

Thanks!