### PR TITLE
Trigger metacall/cli docker-hub workflow before Docker fallback tests

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -6,7 +6,7 @@ jobs:
   trigger-cli-build:
     name: Trigger metacall/cli Build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -4,9 +4,9 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   trigger-cli-build:
-    name: Trigger metacall/cli Build
+    name: Trigger CLI Docker Build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
 
@@ -23,6 +23,7 @@ jobs:
   install-local:
     name: Install Metacall via Default Installation (local)
     runs-on: ubuntu-latest
+    if: always()
     needs: trigger-cli-build
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -8,6 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Trigger metacall/cli Build
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+          with:
+            owner: metacall
+            repo: cli
+            github_token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
+            workflow_file_name: docker-hub.yml
+            wait_workflow: true
+            ref: master
+
       - name: Tests
         run: ./test.sh
 
@@ -18,5 +29,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo "METACALL_INSTALL_CERTS=certificates_remote" >> $GITHUB_ENV
+
+      - name: Trigger metacall/cli Build
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+          with:
+            owner: metacall
+            repo: cli
+            github_token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
+            workflow_file_name: docker-hub.yml
+            wait_workflow: true
+            ref: master
+
       - name: Tests
         run: ./test.sh

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -3,22 +3,29 @@ name: Install Metacall on Linux Test
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  install-local:
-    name: Install Metacall via Default Installation (local)
+  trigger-cli-build:
+    name: Trigger metacall/cli Build
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
 
-      - name: Trigger metacall/cli Build
+      - name: Trigger metacall/cli Build Workflow
         uses: convictional/trigger-workflow-and-wait@v1.6.1
-          with:
-            owner: metacall
-            repo: cli
-            github_token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
-            workflow_file_name: docker-hub.yml
-            wait_workflow: true
-            ref: master
+        with:
+          owner: metacall
+          repo: cli
+          github_token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
+          workflow_file_name: docker-hub.yml
+          wait_workflow: true
+          ref: master
 
+  install-local:
+    name: Install Metacall via Default Installation (local)
+    runs-on: ubuntu-latest
+    needs: trigger-cli-build
+    steps:
+      - uses: actions/checkout@v4
       - name: Tests
         run: ./test.sh
 
@@ -26,19 +33,9 @@ jobs:
     name: Install Metacall via Default Installation (remote)
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
+    needs: trigger-cli-build
     steps:
       - uses: actions/checkout@v4
       - run: echo "METACALL_INSTALL_CERTS=certificates_remote" >> $GITHUB_ENV
-
-      - name: Trigger metacall/cli Build
-        uses: convictional/trigger-workflow-and-wait@v1.6.1
-          with:
-            owner: metacall
-            repo: cli
-            github_token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
-            workflow_file_name: docker-hub.yml
-            wait_workflow: true
-            ref: master
-
       - name: Tests
         run: ./test.sh


### PR DESCRIPTION
This PR fixes #26 by adding a step to trigger the `docker-hub.yml` workflow in the `metacall/cli` repo before running the Docker fallback tests. This ensures the latest CLI image is updated before testing.