### PR TITLE
fixed windows white space installation issue #30

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,7 @@
 #	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #	See the License for the specific language governing permissions and
 #	limitations under the License.
-
+​
 <#
 .SYNOPSIS
 	Installs MetaCall CLI
@@ -34,32 +34,32 @@
 	Default: $null
 	Path to the tarball to be installed. If specified, this parameter will override the Version parameter.
 #>
-
+​
 [cmdletbinding()]
 param(
 	[string]$InstallDir="<auto>",
 	[string]$Version="latest",
 	[string]$FromPath=$null
 )
-
+​
 Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"
 $ProgressPreference="SilentlyContinue"
-
+​
 function Get-Machine-Architecture() {
 	# On PS x86, PROCESSOR_ARCHITECTURE reports x86 even on x64 systems.
 	# To get the correct architecture, we need to use PROCESSOR_ARCHITEW6432.
 	# PS x64 doesn't define this, so we fall back to PROCESSOR_ARCHITECTURE.
 	# Possible values: amd64, x64, x86, arm64, arm
-
+​
 	if( $ENV:PROCESSOR_ARCHITEW6432 -ne $null )
 	{
 		return $ENV:PROCESSOR_ARCHITEW6432
 	}
-
+​
 	return $ENV:PROCESSOR_ARCHITECTURE
 }
-
+​
 function Get-CLI-Architecture() {
 	$Architecture = $(Get-Machine-Architecture)
 	switch ($Architecture.ToLowerInvariant()) {
@@ -71,7 +71,7 @@ function Get-CLI-Architecture() {
 		default { throw "Architecture '$Architecture' not supported. If you are interested in this platform feel free to contribute to https://github.com/metacall/distributable-windows" }
 	}
 }
-
+​
 function Get-User-Share-Path() {
 	$InstallRoot = $env:METACALL_INSTALL_DIR
 	if (!$InstallRoot) {
@@ -79,14 +79,14 @@ function Get-User-Share-Path() {
 	}
 	return $InstallRoot
 }
-
+​
 function Resolve-Installation-Path([string]$InstallDir) {
 	if ($InstallDir -eq "<auto>") {
 		return Get-User-Share-Path
 	}
 	return $InstallDir
 }
-
+​
 function Get-RedirectedUri {
 	<#
 	.SYNOPSIS
@@ -100,7 +100,7 @@ function Get-RedirectedUri {
 	.NOTES
 		Code from: Redone per issue #2896 in core https://github.com/PowerShell/PowerShell/issues/2896
 	#>
-
+​
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true)]
@@ -118,7 +118,7 @@ function Get-RedirectedUri {
 					# This is for Powershell core
 					$redirectUri = $request.BaseResponse.RequestMessage.RequestUri
 				}
-
+​
 				$retry = $false
 			}
 			catch {
@@ -131,11 +131,11 @@ function Get-RedirectedUri {
 				}
 			}
 		} while ($retry)
-
+​
 		$redirectUri
 	}
 }
-
+​
 function Resolve-Version([string]$Version) {
 	if ($Version.ToLowerInvariant() -eq "latest") {
 		$LatestTag = $(Get-RedirectedUri "https://github.com/metacall/distributable-windows/releases/latest")
@@ -145,7 +145,7 @@ function Resolve-Version([string]$Version) {
 		return "v$Version"
 	}
 }
-
+​
 function Post-Install([string]$InstallRoot) {
 	# Reinstall Python Pip to the latest version (needed in order to patch the python.exe location)
 	$InstallLocation = Join-Path -Path $InstallRoot -ChildPath "metacall"
@@ -160,35 +160,35 @@ endlocal
 	# PIP_TARGET here might be incorrect here, for more info check https://github.com/metacall/distributable-windows/pull/20
 	$InstallPythonScriptOneLine = $($InstallPythonScript.Trim()).replace("`n", " && ")
 	cmd /V /C "$InstallPythonScriptOneLine"
-
+​
 	# Install Additional Packages
 	Install-MetaCall-AdditionalPackages -Component "deploy"
 	Install-MetaCall-AdditionalPackages -Component "faas"
-
+​
 	# TODO: Replace in the files D:/ and D:\
 }
-
+​
 function Path-Install([string]$InstallRoot) {
 	# Add safely MetaCall command to the PATH (and persist it)
-
+​
 	# To add folder containing metacall.bat to PATH
 	$persistedPaths = [Environment]::GetEnvironmentVariable('PATH', [EnvironmentVariableTarget]::User) -split ';'
 	if ($persistedPaths -notcontains $InstallRoot) {
 		[Environment]::SetEnvironmentVariable('PATH', $env:PATH+";"+$InstallRoot, [EnvironmentVariableTarget]::User)
 	}
-
+​
 	# To verify if PATH isn't already added
 	$envPaths = $env:Path -split ';'
 	if ($envPaths -notcontains $InstallRoot) {
 		$envPaths = $envPaths + $InstallRoot | where { $_ }
 		$env:Path = $envPaths -join ';'
 	}
-
+​
 	if ($env:GITHUB_ENV -ne $null) {
 		echo "PATH=$env:PATH" >> $env:GITHUB_ENV
 	}
 }
-
+​
 # TODO: Use this for implementing uninstall
 function Path-Uninstall([string]$Path) {
 	$persistedPaths = [Environment]::GetEnvironmentVariable('PATH', [EnvironmentVariableTarget]::User) -split ';'
@@ -196,82 +196,84 @@ function Path-Uninstall([string]$Path) {
 		$persistedPaths = $persistedPaths | where { $_ -and $_ -ne $Path }
 		[Environment]::SetEnvironmentVariable('PATH', $persistedPaths -join ';', [EnvironmentVariableTarget]::User)
 	}
-
+​
 	$envPaths = $env:Path -split ';'
 	if ($envPaths -contains $Path) {
 		$envPaths = $envPaths | where { $_ -and $_ -ne $Path }
 		$env:Path = $envPaths -join ';'
 	}
 }
-
+​
 function Install-Tarball([string]$InstallDir, [string]$Version) {
 	$InstallRoot = Resolve-Installation-Path $InstallDir
 	$InstallOutput = Join-Path -Path $InstallRoot -ChildPath "metacall-tarball-win.zip"
-        # Delete directory contents if any
-        if (Test-Path $InstallRoot) {
-           Remove-Item -Recurse -Force $InstallRoot | Out-Null
-        }
-
-        # Create directory if it does not exist
-        New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+		# Delete directory contents if any
+		if (Test-Path $InstallRoot) {
+		   Remove-Item -Recurse -Force $InstallRoot | Out-Null
+		}
+​
+		# Create directory if it does not exist
+		New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 	
-        if (!$FromPath) { 
-           $InstallVersion = Resolve-Version $Version
-           $InstallArchitecture = Get-CLI-Architecture
-           $DownloadUri = "https://github.com/metacall/distributable-windows/releases/download/$InstallVersion/metacall-tarball-win-$InstallArchitecture.zip"
-
-           # Download the tarball
-           Invoke-WebRequest -Uri $DownloadUri -OutFile $InstallOutput
+		if (!$FromPath) { 
+		   $InstallVersion = Resolve-Version $Version
+		   $InstallArchitecture = Get-CLI-Architecture
+		   $DownloadUri = "https://github.com/metacall/distributable-windows/releases/download/$InstallVersion/metacall-tarball-win-$InstallArchitecture.zip"
+​
+		   # Download the tarball
+		   Invoke-WebRequest -Uri $DownloadUri -OutFile $InstallOutput
 	} else {
-           # Copy the tarball from the path
-           Copy-Item -Path $FromPath -Destination $InstallOutput
+		   # Copy the tarball from the path
+		   Copy-Item -Path $FromPath -Destination $InstallOutput
 	}
-
+​
 	# Unzip the tarball
 	Expand-Archive -Path $InstallOutput -DestinationPath $InstallRoot -Force
-
+​
 	# Delete the tarball
 	Remove-Item -Force $InstallOutput | Out-Null
-
+​
 	# Run post install scripts
 	Post-Install $InstallRoot
-
+​
 	# Add MetaCall CLI to PATH
 	Path-Install $InstallRoot
 }
-
+​
 function Set-NodePath {
-    param (
-        [string]$FilePath
-    )
+	param (
+		[string]$FilePath
+	)
 	$NodePath = "`"$env:LocalAppData\MetaCall\metacall\runtimes\nodejs\node.exe`""
-
-    if (-not (Test-Path $FilePath)) {
-        Write-Error "The file $FilePath does not exist."
-        return
-    }
-    $content = Get-Content -Path $FilePath
-    $content = $content -replace '%dp0%\\node.exe', $NodePath
-    $content = $content -replace '""', '"'
-    Set-Content -Path $FilePath -Value $content
+	if (-not (Test-Path $FilePath)) {
+		Write-Error "The file $FilePath does not exist."
+		return
+	}
+​
+	$content = Get-Content -Path $FilePath
+	$content = $content -replace '%dp0%\\node.exe', $NodePath
+	$content = $content -replace '""', '"'
+​
+	Set-Content -Path $FilePath -Value $content
 }
-
+​
 function Install-MetaCall-AdditionalPackages {
-    param (
-        [string]$Component
-    )
-    $InstallRoot = Resolve-Installation-Path $InstallDir
-    $InstallDir = Join-Path -Path $InstallRoot -ChildPath "deps\$Component"
-
-    if (-not (Test-Path $InstallDir)) {
-        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-    }
-
-    Write-Host "MetaCall $($Component) Installation"
-    Invoke-Expression "npm install --global --prefix=`"$InstallDir`" @metacall/$Component"
-	Set-NodePath  "$InstallDir\metacall-$Component.cmd"
-    Write-Host "MetaCall $Component has been installed."
+	param (
+		[string]$Component
+	)
+​
+	$InstallRoot = Resolve-Installation-Path $InstallDir
+	$InstallDir = Join-Path -Path "$InstallRoot" -ChildPath "deps\$Component"
+​
+	if (-not (Test-Path $InstallDir)) {
+		New-Item -ItemType Directory -Force -Path "$InstallDir" | Out-Null
+	}
+​
+	Write-Host "MetaCall $($Component) Installation"
+	Invoke-Expression "npm install --global --prefix=`"$InstallDir`" @metacall/$Component"
+	Set-NodePath "$InstallDir\metacall-$Component.cmd"
+	Write-Host "MetaCall $Component has been installed."
 }
-
+​
 # Install the tarball and post scripts
 Install-Tarball $InstallDir $Version

--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,7 @@
 #	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #	See the License for the specific language governing permissions and
 #	limitations under the License.
-​
+
 <#
 .SYNOPSIS
 	Installs MetaCall CLI
@@ -34,32 +34,32 @@
 	Default: $null
 	Path to the tarball to be installed. If specified, this parameter will override the Version parameter.
 #>
-​
+
 [cmdletbinding()]
 param(
 	[string]$InstallDir="<auto>",
 	[string]$Version="latest",
 	[string]$FromPath=$null
 )
-​
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"
 $ProgressPreference="SilentlyContinue"
-​
+
 function Get-Machine-Architecture() {
 	# On PS x86, PROCESSOR_ARCHITECTURE reports x86 even on x64 systems.
 	# To get the correct architecture, we need to use PROCESSOR_ARCHITEW6432.
 	# PS x64 doesn't define this, so we fall back to PROCESSOR_ARCHITECTURE.
 	# Possible values: amd64, x64, x86, arm64, arm
-​
+
 	if( $ENV:PROCESSOR_ARCHITEW6432 -ne $null )
 	{
 		return $ENV:PROCESSOR_ARCHITEW6432
 	}
-​
+
 	return $ENV:PROCESSOR_ARCHITECTURE
 }
-​
+
 function Get-CLI-Architecture() {
 	$Architecture = $(Get-Machine-Architecture)
 	switch ($Architecture.ToLowerInvariant()) {
@@ -71,7 +71,7 @@ function Get-CLI-Architecture() {
 		default { throw "Architecture '$Architecture' not supported. If you are interested in this platform feel free to contribute to https://github.com/metacall/distributable-windows" }
 	}
 }
-​
+
 function Get-User-Share-Path() {
 	$InstallRoot = $env:METACALL_INSTALL_DIR
 	if (!$InstallRoot) {
@@ -79,14 +79,14 @@ function Get-User-Share-Path() {
 	}
 	return $InstallRoot
 }
-​
+
 function Resolve-Installation-Path([string]$InstallDir) {
 	if ($InstallDir -eq "<auto>") {
 		return Get-User-Share-Path
 	}
 	return $InstallDir
 }
-​
+
 function Get-RedirectedUri {
 	<#
 	.SYNOPSIS
@@ -100,7 +100,7 @@ function Get-RedirectedUri {
 	.NOTES
 		Code from: Redone per issue #2896 in core https://github.com/PowerShell/PowerShell/issues/2896
 	#>
-​
+
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true)]
@@ -118,7 +118,7 @@ function Get-RedirectedUri {
 					# This is for Powershell core
 					$redirectUri = $request.BaseResponse.RequestMessage.RequestUri
 				}
-​
+
 				$retry = $false
 			}
 			catch {
@@ -131,11 +131,11 @@ function Get-RedirectedUri {
 				}
 			}
 		} while ($retry)
-​
+
 		$redirectUri
 	}
 }
-​
+
 function Resolve-Version([string]$Version) {
 	if ($Version.ToLowerInvariant() -eq "latest") {
 		$LatestTag = $(Get-RedirectedUri "https://github.com/metacall/distributable-windows/releases/latest")
@@ -145,7 +145,7 @@ function Resolve-Version([string]$Version) {
 		return "v$Version"
 	}
 }
-​
+
 function Post-Install([string]$InstallRoot) {
 	# Reinstall Python Pip to the latest version (needed in order to patch the python.exe location)
 	$InstallLocation = Join-Path -Path $InstallRoot -ChildPath "metacall"
@@ -160,35 +160,35 @@ endlocal
 	# PIP_TARGET here might be incorrect here, for more info check https://github.com/metacall/distributable-windows/pull/20
 	$InstallPythonScriptOneLine = $($InstallPythonScript.Trim()).replace("`n", " && ")
 	cmd /V /C "$InstallPythonScriptOneLine"
-​
+
 	# Install Additional Packages
 	Install-MetaCall-AdditionalPackages -Component "deploy"
 	Install-MetaCall-AdditionalPackages -Component "faas"
-​
+
 	# TODO: Replace in the files D:/ and D:\
 }
-​
+
 function Path-Install([string]$InstallRoot) {
 	# Add safely MetaCall command to the PATH (and persist it)
-​
+
 	# To add folder containing metacall.bat to PATH
 	$persistedPaths = [Environment]::GetEnvironmentVariable('PATH', [EnvironmentVariableTarget]::User) -split ';'
 	if ($persistedPaths -notcontains $InstallRoot) {
 		[Environment]::SetEnvironmentVariable('PATH', $env:PATH+";"+$InstallRoot, [EnvironmentVariableTarget]::User)
 	}
-​
+
 	# To verify if PATH isn't already added
 	$envPaths = $env:Path -split ';'
 	if ($envPaths -notcontains $InstallRoot) {
 		$envPaths = $envPaths + $InstallRoot | where { $_ }
 		$env:Path = $envPaths -join ';'
 	}
-​
+
 	if ($env:GITHUB_ENV -ne $null) {
 		echo "PATH=$env:PATH" >> $env:GITHUB_ENV
 	}
 }
-​
+
 # TODO: Use this for implementing uninstall
 function Path-Uninstall([string]$Path) {
 	$persistedPaths = [Environment]::GetEnvironmentVariable('PATH', [EnvironmentVariableTarget]::User) -split ';'
@@ -196,84 +196,81 @@ function Path-Uninstall([string]$Path) {
 		$persistedPaths = $persistedPaths | where { $_ -and $_ -ne $Path }
 		[Environment]::SetEnvironmentVariable('PATH', $persistedPaths -join ';', [EnvironmentVariableTarget]::User)
 	}
-​
+
 	$envPaths = $env:Path -split ';'
 	if ($envPaths -contains $Path) {
 		$envPaths = $envPaths | where { $_ -and $_ -ne $Path }
 		$env:Path = $envPaths -join ';'
 	}
 }
-​
+
 function Install-Tarball([string]$InstallDir, [string]$Version) {
 	$InstallRoot = Resolve-Installation-Path $InstallDir
 	$InstallOutput = Join-Path -Path $InstallRoot -ChildPath "metacall-tarball-win.zip"
-		# Delete directory contents if any
-		if (Test-Path $InstallRoot) {
-		   Remove-Item -Recurse -Force $InstallRoot | Out-Null
-		}
-​
-		# Create directory if it does not exist
-		New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+        # Delete directory contents if any
+        if (Test-Path $InstallRoot) {
+           Remove-Item -Recurse -Force $InstallRoot | Out-Null
+        }
+
+        # Create directory if it does not exist
+        New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 	
-		if (!$FromPath) { 
-		   $InstallVersion = Resolve-Version $Version
-		   $InstallArchitecture = Get-CLI-Architecture
-		   $DownloadUri = "https://github.com/metacall/distributable-windows/releases/download/$InstallVersion/metacall-tarball-win-$InstallArchitecture.zip"
-​
-		   # Download the tarball
-		   Invoke-WebRequest -Uri $DownloadUri -OutFile $InstallOutput
+        if (!$FromPath) { 
+           $InstallVersion = Resolve-Version $Version
+           $InstallArchitecture = Get-CLI-Architecture
+           $DownloadUri = "https://github.com/metacall/distributable-windows/releases/download/$InstallVersion/metacall-tarball-win-$InstallArchitecture.zip"
+
+           # Download the tarball
+           Invoke-WebRequest -Uri $DownloadUri -OutFile $InstallOutput
 	} else {
-		   # Copy the tarball from the path
-		   Copy-Item -Path $FromPath -Destination $InstallOutput
+           # Copy the tarball from the path
+           Copy-Item -Path $FromPath -Destination $InstallOutput
 	}
-​
+
 	# Unzip the tarball
 	Expand-Archive -Path $InstallOutput -DestinationPath $InstallRoot -Force
-​
+
 	# Delete the tarball
 	Remove-Item -Force $InstallOutput | Out-Null
-​
+
 	# Run post install scripts
 	Post-Install $InstallRoot
-​
+
 	# Add MetaCall CLI to PATH
 	Path-Install $InstallRoot
 }
-​
+
 function Set-NodePath {
 	param (
 		[string]$FilePath
 	)
-	$NodePath = "`"$env:LocalAppData\MetaCall\metacall\runtimes\nodejs\node.exe`""
+	$NodePath = "$env:LocalAppData\MetaCall\metacall\runtimes\nodejs\node.exe"
 	if (-not (Test-Path $FilePath)) {
 		Write-Error "The file $FilePath does not exist."
 		return
 	}
-​
 	$content = Get-Content -Path $FilePath
 	$content = $content -replace '%dp0%\\node.exe', $NodePath
 	$content = $content -replace '""', '"'
-​
 	Set-Content -Path $FilePath -Value $content
 }
-​
+
 function Install-MetaCall-AdditionalPackages {
 	param (
 		[string]$Component
 	)
-​
-	$InstallRoot = Resolve-Installation-Path $InstallDir
+	$InstallRoot = Resolve-Installation-Path "$InstallDir"
 	$InstallDir = Join-Path -Path "$InstallRoot" -ChildPath "deps\$Component"
-​
+
 	if (-not (Test-Path $InstallDir)) {
 		New-Item -ItemType Directory -Force -Path "$InstallDir" | Out-Null
 	}
-​
+
 	Write-Host "MetaCall $($Component) Installation"
 	Invoke-Expression "npm install --global --prefix=`"$InstallDir`" @metacall/$Component"
-	Set-NodePath "$InstallDir\metacall-$Component.cmd"
+	Set-NodePath  "$InstallDir\metacall-$Component.cmd"
 	Write-Host "MetaCall $Component has been installed."
 }
-​
+
 # Install the tarball and post scripts
 Install-Tarball $InstallDir $Version

--- a/install.ps1
+++ b/install.ps1
@@ -244,15 +244,15 @@ function Set-NodePath {
 	param (
 		[string]$FilePath
 	)
-	$NodePath = "$env:LocalAppData\MetaCall\metacall\runtimes\nodejs\node.exe"
+	$NodePath = "`"$env:LocalAppData\MetaCall\metacall\runtimes\nodejs\node.exe`""
 	if (-not (Test-Path $FilePath)) {
 		Write-Error "The file $FilePath does not exist."
 		return
 	}
-	$content = Get-Content -Path $FilePath
-	$content = $content -replace '%dp0%\\node.exe', $NodePath
+	$content = Get-Content -Path "$FilePath"
+	$content = $content -replace '%dp0%\\node.exe', "$NodePath"
 	$content = $content -replace '""', '"'
-	Set-Content -Path $FilePath -Value $content
+	Set-Content -Path "$FilePath" -Value "$content"
 }
 
 function Install-MetaCall-AdditionalPackages {
@@ -268,7 +268,7 @@ function Install-MetaCall-AdditionalPackages {
 
 	Write-Host "MetaCall $($Component) Installation"
 	Invoke-Expression "npm install --global --prefix=`"$InstallDir`" @metacall/$Component"
-	Set-NodePath  "$InstallDir\metacall-$Component.cmd"
+	Set-NodePath "$InstallDir\metacall-$Component.cmd"
 	Write-Host "MetaCall $Component has been installed."
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -244,7 +244,8 @@ function Set-NodePath {
     param (
         [string]$FilePath
     )
-	$NodePath = "$env:LocalAppData\MetaCall\metacall\runtimes\nodejs\node.exe"
+	$NodePath = "`"$env:LocalAppData\MetaCall\metacall\runtimes\nodejs\node.exe`""
+
     if (-not (Test-Path $FilePath)) {
         Write-Error "The file $FilePath does not exist."
         return
@@ -267,7 +268,7 @@ function Install-MetaCall-AdditionalPackages {
     }
 
     Write-Host "MetaCall $($Component) Installation"
-    Invoke-Expression "npm install --global --prefix=$InstallDir @metacall/$Component"
+    Invoke-Expression "npm install --global --prefix=`"$InstallDir`" @metacall/$Component"
 	Set-NodePath  "$InstallDir\metacall-$Component.cmd"
     Write-Host "MetaCall $Component has been installed."
 }


### PR DESCRIPTION
## Pull Request: Fix for Issue #30

**Description:**

This pull request addresses issue #30 by updating the script to handle paths with spaces in the user name. The problem arose because the script failed to recognize paths containing whitespace, causing the installation process to stop.

### Changes made:
- Added quotes around file paths to ensure paths with spaces are properly recognized and handled.
- Tested on a Windows machine with a user name that includes spaces to verify the fix.

This change ensures that the installation works correctly even when the user name contains whitespace.

## Result:
![Screenshot 2024-10-10 213612](https://github.com/user-attachments/assets/4678fed2-aedc-4585-97d4-70e8c215e58e)

