### PR TITLE
Added Test for OpenCV

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -224,22 +224,27 @@ jobs:
         shell: cmd
         run: |
           metacall pip install -r test/opencv/requirements.txt | findstr "Successfully installed"
+          IF %ERRORLEVEL% NEQ 0 exit /B 1
 
       # For some reason, OpenCV fails if you do not reinstall numpy
       - name: Python OpenCV Test (Uninstall Numpy for OpenCV)
         shell: cmd
         run: |
           metacall pip uninstall numpy --yes
+          IF %ERRORLEVEL% NEQ 0 exit /B 1
 
+      # For some reason, it needs to be split into two different steps
       - name: Python OpenCV Test (Install Numpy for OpenCV)
         shell: cmd
         run: |
           metacall pip install numpy==1.21.6
+          IF %ERRORLEVEL% NEQ 0 exit /B 1
 
       - name: Python OpenCV Test (Test OpenCV)
         shell: cmd
         run: |
           metacall ./test/opencv/opencv.py | findstr "OpenCV Version: 3.4.11"
+          IF %ERRORLEVEL% NEQ 0 exit /B 1
 
       - name: Deploy & FaaS Test
         shell: cmd

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -220,25 +220,22 @@ jobs:
           metacall ./test/requirements.py | findstr "123456"
           IF %ERRORLEVEL% NEQ 0 exit /B 1
 
-      - name: Python OpenCV Test (install OpenCV)
+      - name: Python OpenCV Test (Install OpenCV)
         shell: cmd
         run: |
-          metacall pip install -r test/opencv/requirements.txt
+          metacall pip install -r test/opencv/requirements.txt | findstr "Successfully installed"
 
-      - name: Python OpenCV Test (Uninstall Numpy came with OpenCV)
+      # For some reason, OpenCV fails if you do not reinstall numpy
+      - name: Python OpenCV Test (Reinstall Numpy for OpenCV)
         shell: cmd
         run: |
           metacall pip uninstall numpy --yes
-
-      - name: Python OpenCV Test (install Numpy==1.21.6)
-        shell: cmd
-        run: |
           metacall pip install numpy==1.21.6
         
-      - name: Python OpenCV Test (Test opencv.py)
+      - name: Python OpenCV Test (Test OpenCV)
         shell: cmd
         run: |
-          metacall ./test/opencv/opencv.py
+          metacall ./test/opencv/opencv.py | findstr "OpenCV Version: 3.4.11"
 
       - name: Deploy & FaaS Test
         shell: cmd

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Python OpenCV Test (Uninstall Numpy came with OpenCV)
         shell: cmd
         run: |
-          metacall pip uninstall numpy -yes
+          metacall pip uninstall numpy --yes
 
       - name: Python OpenCV Test (install Numpy==1.21.6)
         shell: cmd

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -226,12 +226,16 @@ jobs:
           metacall pip install -r test/opencv/requirements.txt | findstr "Successfully installed"
 
       # For some reason, OpenCV fails if you do not reinstall numpy
-      - name: Python OpenCV Test (Reinstall Numpy for OpenCV)
+      - name: Python OpenCV Test (Uninstall Numpy for OpenCV)
         shell: cmd
         run: |
           metacall pip uninstall numpy --yes
+
+      - name: Python OpenCV Test (Install Numpy for OpenCV)
+        shell: cmd
+        run: |
           metacall pip install numpy==1.21.6
-        
+
       - name: Python OpenCV Test (Test OpenCV)
         shell: cmd
         run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -233,7 +233,7 @@ jobs:
           metacall pip uninstall numpy --yes
           IF %ERRORLEVEL% NEQ 0 exit /B 1
 
-      # For some reason, it needs to be split into two different steps
+      # For some reason, it needs to be split into two different steps in order to work
       - name: Python OpenCV Test (Install Numpy for OpenCV)
         shell: cmd
         run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -220,11 +220,24 @@ jobs:
           metacall ./test/requirements.py | findstr "123456"
           IF %ERRORLEVEL% NEQ 0 exit /B 1
 
-      - name: Python OpenCV Test
+      - name: Python OpenCV Test (install OpenCV)
         shell: cmd
         run: |
           metacall pip install -r test/opencv/requirements.txt
-          metacall pip uninstall numpy -y
+
+      - name: Python OpenCV Test (Uninstall Numpy came with OpenCV)
+        shell: cmd
+        run: |
+          metacall pip uninstall numpy -yes
+
+      - name: Python OpenCV Test (install Numpy==1.21.6)
+        shell: cmd
+        run: |
+          metacall pip install numpy==1.21.6
+        
+      - name: Python OpenCV Test (Test opencv.py)
+        shell: cmd
+        run: |
           metacall ./test/opencv/opencv.py
 
       - name: Deploy & FaaS Test

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -224,7 +224,7 @@ jobs:
         shell: cmd
         run: |
           metacall pip install -r test/opencv/requirements.txt
-          metacall pip uninstall numpy -y && metacall pip install numpy==1.21.6 # uninstall numpy came with Open CV and install version 1.21.6
+          metacall pip uninstall numpy -y
           metacall ./test/opencv/opencv.py
 
       - name: Deploy & FaaS Test

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -224,6 +224,7 @@ jobs:
         shell: cmd
         run: |
           metacall pip install -r test/opencv/requirements.txt
+          metacall pip uninstall numpy -y && metacall pip install numpy==1.21.6 # uninstall numpy came with Open CV and install version 1.21.6
           metacall ./test/opencv/opencv.py
 
       - name: Deploy & FaaS Test

--- a/test/opencv/opencv.py
+++ b/test/opencv/opencv.py
@@ -1,2 +1,2 @@
 import cv2
-print("OpenCV-version", cv2.__version__)
+print("OpenCV Version", cv2.__version__)

--- a/test/opencv/opencv.py
+++ b/test/opencv/opencv.py
@@ -1,3 +1,2 @@
 import cv2
-print("OpenCV-version ",cv2.__version__)
-print('123456')
+print("OpenCV-version", cv2.__version__)

--- a/test/opencv/opencv.py
+++ b/test/opencv/opencv.py
@@ -1,3 +1,3 @@
 import cv2
-print(cv2.__version__)
+print("OpenCV-version ",cv2.__version__)
 print('123456')

--- a/test/opencv/requirements.txt
+++ b/test/opencv/requirements.txt
@@ -1,2 +1,1 @@
-opencv-contrib-python-headless==3.4.11.45
-numpy==1.21.6
+opencv-contrib-python==3.4.11.45


### PR DESCRIPTION
### Added Test for OpenCV Version Compatibility in MetaCall on Windows

**Issue Summary:**
In response to the issue reported in [PR #33](https://github.com/metacall/install/pull/33), where OpenCV (cv2) was failing to load within MetaCall on Windows 11, we have identified that the error was caused by incompatible versions of OpenCV and NumPy.

Use the following command to install the compatible OpenCV.
Open command prompt and run:-
```plaintext
metacall pip install opencv-contrib-python==3.4.11.45
metacall pip uninstall numpy --yes     #this is to uninstall the numpy which came with OpenCV installation
metacall pip install numpy==1.21.6
```